### PR TITLE
[EventDispatcher] allow anonymous (without namespace) EventDispatcher

### DIFF
--- a/packages/core/src/services/event-dispatcher.service.spec.ts
+++ b/packages/core/src/services/event-dispatcher.service.spec.ts
@@ -74,7 +74,7 @@ describe("riba.core", () => {
     });
 
 
-    it("All event listeners for a given event name and handler should only be removed if only the event name is supplied to 'off()'", () => {
+    it("All event listeners for a given event name should only be removed if only the event name is supplied to 'off()'", () => {
       let value: any = 1;
       const thisContext = { value: 7452 };
       const thatContext = { value: 666 };
@@ -96,7 +96,7 @@ describe("riba.core", () => {
       expect(value).toBe(1);
     });
     
-    it("All event listeners for all events should be removed no arguments are supplied to 'off()'", () => {
+    it("All event listeners for all events should be removed if no arguments are supplied to 'off()'", () => {
       let value1: any = 1;
       let value2: any = 2;
       let value3: any = 3;

--- a/packages/core/src/services/event-dispatcher.service.spec.ts
+++ b/packages/core/src/services/event-dispatcher.service.spec.ts
@@ -9,16 +9,16 @@ describe("riba.core", () => {
       eventDispatcher = new EventDispatcher();
     });
 
-    it("The event dispatcher should call a simple function on all event listeners if trigger function is called", (done) => {
+    it("The event dispatcher should call a simple function on all event listeners if trigger function is called", () => {
       let listener1 = jest.fn();
       let listener2 = jest.fn();
       let listener3 = jest.fn();
-      eventDispatcher.on("test1", () => listener1);
-      eventDispatcher.on("test2", () => listener1);
-      eventDispatcher.on("test2", () => listener2);
-      eventDispatcher.on("test3", () => listener1);
-      eventDispatcher.on("test3", () => listener2);
-      eventDispatcher.on("test3", () => listener3);
+      eventDispatcher.on("test1", listener1);
+      eventDispatcher.on("test2", listener1);
+      eventDispatcher.on("test2", listener2);
+      eventDispatcher.on("test3", listener1);
+      eventDispatcher.on("test3", listener2);
+      eventDispatcher.on("test3", listener3);
       eventDispatcher.trigger("test1");
       eventDispatcher.trigger("test2");
       eventDispatcher.trigger("test3");
@@ -51,22 +51,26 @@ describe("riba.core", () => {
     it("The event listener should only be removed according to supplied arguments", () => {
       let value: any = 1;
       let thisContext = { value: 7452 }
-      let testFunction = function(this: {value: number}) {
-        value = this.value;
+      const obj = {
+        value: 42,
+        testFunction: function(this: {value: number}) {
+          value = this.value;
+        }
       };
-      eventDispatcher.on("test1", testFunction, thisContext);
-      eventDispatcher.off("test1", testFunction, { number: 7452})
+      eventDispatcher.on("test1", obj.testFunction, thisContext);
+      eventDispatcher.off("test1", obj.testFunction, { number: 7452})
       eventDispatcher.trigger("test1");
       expect(value).toBe(7452); //test if testFunction is still active
       
       value = undefined;
-      eventDispatcher.off("test1", testFunction, thisContext);
+      eventDispatcher.off("test1", obj.testFunction, thisContext);
       expect(value).toBe(undefined); //test if testFunction is removed
 
-      eventDispatcher.on("test1", testFunction, thisContext);
-      eventDispatcher.off("test1", testFunction)
+      eventDispatcher.on("test1", obj.testFunction, thisContext);
+      eventDispatcher.on("test1", obj.testFunction, obj);
+      eventDispatcher.off("test1", obj.testFunction, thisContext);
       eventDispatcher.trigger("test1");
-      expect(value).toBe(undefined); //test if testFunction is removed
+      expect(value).toBe(42); //test if testFunction is removed
     });
 
 

--- a/packages/core/src/services/event-dispatcher.service.spec.ts
+++ b/packages/core/src/services/event-dispatcher.service.spec.ts
@@ -1,34 +1,54 @@
 import { EventDispatcher } from './event-dispatcher.service';
 
-describe('riba.core', () => {
-  describe('EventDispatcher', () => {
+describe("riba.core", () => {
+  describe("EventDispatcher", () => {
     let eventDispatcher: EventDispatcher;
 
     beforeEach(() => {
       EventDispatcher.instances = {}; //clear all old event dispatcher instances
-      eventDispatcher = new EventDispatcher(); //aquire singleton
+      eventDispatcher = new EventDispatcher();
     });
 
-    it('The event dispatcher should call a simple function on all event listeners if trigger function is called', () => {
-      let fail: boolean = true;
-      eventDispatcher.on("test1", () => {
-        fail = false;
-      });
+    it("The event dispatcher should call a simple function on all event listeners if trigger function is called", (done) => {
+      let listener1 = jest.fn();
+      let listener2 = jest.fn();
+      let listener3 = jest.fn();
+      eventDispatcher.on("test1", () => listener1);
+      eventDispatcher.on("test2", () => listener1);
+      eventDispatcher.on("test2", () => listener2);
+      eventDispatcher.on("test3", () => listener1);
+      eventDispatcher.on("test3", () => listener2);
+      eventDispatcher.on("test3", () => listener3);
       eventDispatcher.trigger("test1");
-      expect(fail).toBeFalse();
+      eventDispatcher.trigger("test2");
+      eventDispatcher.trigger("test3");
+      expect(listener1.mock.calls.length).toBe(3);
+      expect(listener2.mock.calls.length).toBe(2);
+      expect(listener3.mock.calls.length).toBe(1);
     });
 
     //passed
-    it('The event dispatcher should use the given thisContext for all handlers', () => {
-      let value: number = 1;
-      eventDispatcher.on("test1", function(this: {value: number}) {
-        value = this.value;
-      }, { value: 7452 });
+    it("The event dispatcher should use the given thisContext for all handlers", () => {
+      let obj1 = {
+        value: 1
+      };
+      let obj2 = {
+        value: 2
+      };
+      let obj3 = {
+        value: 3
+      };
+      const handler = jest.fn(function(this: {name: string}) { return (this as any).value });
+      eventDispatcher.on("test1", handler, obj1);
+      eventDispatcher.on("test2", handler, obj2);
+      eventDispatcher.on("test3", handler, obj3);
       eventDispatcher.trigger("test1");
-      expect(value).toBe(7452);
+      eventDispatcher.trigger("test2");
+      eventDispatcher.trigger("test3");
+      expect(handler.mock.results.map(r => r.value)).toEqual([1, 2, 3]);
     });
 
-    it('The event listener should only be removed according to supplied arguments', () => {
+    it("The event listener should only be removed according to supplied arguments", () => {
       let value: any = 1;
       let thisContext = { value: 7452 }
       let testFunction = function(this: {value: number}) {
@@ -49,17 +69,113 @@ describe('riba.core', () => {
       expect(value).toBe(undefined); //test if testFunction is removed
     });
 
-    it('Every event listener should only be removed if only one argument is supplied to off()', () => {
+
+    it("All event listeners for a given event name and handler should only be removed if only the event name is supplied to 'off()'", () => {
       let value: any = 1;
-      let thisContext = { value: 7452 }
-      let testFunction = function(this: {value: number}) {
-        value = this.value;
+      const thisContext = { value: 7452 };
+      const thatContext = { value: 666 };
+      const obj = {
+        value: 42,
+        testFunction: function(this: {value: number}) {
+          value = this.value;
+        },
       };
-      eventDispatcher.on("test1", testFunction, thisContext);
-      eventDispatcher.on("test1", testFunction);
-      eventDispatcher.off("test1")
+      eventDispatcher.on("test1", obj.testFunction);
+      eventDispatcher.on("test1", obj.testFunction, thatContext);
+      eventDispatcher.on("test1", obj.testFunction, thisContext);
+      eventDispatcher.off("test1", obj.testFunction, thisContext);
+      eventDispatcher.on("test1", () => value = 23);
+      
+      eventDispatcher.off("test1");
       eventDispatcher.trigger("test1");
+      // No event handler got triggered: value still 1
       expect(value).toBe(1);
+    });
+    
+    it("All event listeners for all events should be removed no arguments are supplied to 'off()'", () => {
+      let value1: any = 1;
+      let value2: any = 2;
+      let value3: any = 3;
+      const thisContext = { value: 7452 };
+      const thatContext = { value: 666 };
+      const obj = {
+        value: 42,
+        testFunction1: function(this: {value: number}) {
+          value1 = this.value;
+        },
+      };
+      function testFunction2() {
+        value2 = "All your base are belong to us.";
+      }
+      function testFunction3() {
+        value3 = "All my base are belong to yours.";
+      }
+      eventDispatcher.on("test1", obj.testFunction1);
+      eventDispatcher.on("test2", obj.testFunction1, thatContext);
+      eventDispatcher.on("test3", obj.testFunction1, thisContext);
+      eventDispatcher.on("test1", obj.testFunction1, thisContext);
+      eventDispatcher.on("test4", () => value1 = 777);
+      eventDispatcher.on("test5", testFunction2);
+      eventDispatcher.on("test6", testFunction3);
+
+      // remove all listeners for all events
+      eventDispatcher.off();
+
+      eventDispatcher.trigger("test1");
+      eventDispatcher.trigger("test2");
+      eventDispatcher.trigger("test3");
+      eventDispatcher.trigger("test4");
+      eventDispatcher.trigger("test5");
+      eventDispatcher.trigger("test6");
+
+      // Expect that nothing has changed
+      expect(value1).toBe(1);
+      expect(value2).toBe(2);
+      expect(value3).toBe(3);
+    });
+
+    it("'new EventDispatcher()' without arguments should always return a new independent EventDispatcher instance", () => {
+      let dispatcher1 = new EventDispatcher();
+      let dispatcher2 = new EventDispatcher();
+      let dispatcher3 = new EventDispatcher();
+      // These should all be different objects:
+      expect(dispatcher1).not.toBe(dispatcher2);
+      expect(dispatcher2).not.toBe(dispatcher3);
+      expect(dispatcher3).not.toBe(dispatcher1);
+    });
+
+    it("'new EventDispatcher(namespace)' should return the same instance for given namespace", () => {
+      let dispatcher1 = new EventDispatcher("number1");
+      let dispatcher2 = new EventDispatcher("number1");
+      let dispatcher3 = new EventDispatcher("number2");
+      let dispatcher4 = new EventDispatcher("number2");
+      // Expect dispatcher1 === dispatcher2 && dispatcher 3 === dispatcher4 && dispatcher 1 !== dispatcher3
+      expect(dispatcher1).toBe(dispatcher2);
+      expect(dispatcher3).toBe(dispatcher4);
+      expect(dispatcher1).not.toBe(dispatcher3);
+    });
+
+    it("'EventDispatcher.getInstance(namespace)' and 'new EventDispatcher(namespace)' should yield the same result, regardless of order", () => {
+      let dispatcher1 = new EventDispatcher("this is my name");
+      let dispatcher2 = EventDispatcher.getInstance("this is my name");
+
+      let dispatcher3 = EventDispatcher.getInstance("the bird is the word");
+      let dispatcher4 = new EventDispatcher("the bird is the word");
+      // Expect dispatcher1 === dispatcher2 && dispatcher 3 === dispatcher4 && dispatcher 1 !== dispatcher3
+      expect(dispatcher1).toBe(dispatcher2);
+      expect(dispatcher3).toBe(dispatcher4);
+      expect(dispatcher1).not.toBe(dispatcher3);
+    });
+
+    it("'EventDispatcher.getInstance()' should return 'EventDispatcher.getInstance(\"main\")'", () => {
+      let dispatcher1 = EventDispatcher.getInstance();
+      let dispatcher2 = EventDispatcher.getInstance("main");
+      let dispatcher3 = new EventDispatcher("main");
+
+      // Expect them all to be equal.
+      expect(dispatcher1).toBe(dispatcher2);
+      expect(dispatcher2).toBe(dispatcher3);
+      expect(dispatcher3).toBe(dispatcher1);
     });
   });
 });

--- a/packages/core/src/services/event-dispatcher.service.ts
+++ b/packages/core/src/services/event-dispatcher.service.ts
@@ -13,7 +13,7 @@ import {
 export class EventDispatcher {
   public static instances: EventDispatcherInstances = {};
 
-  public static getInstance(namespace: string) {
+  public static getInstance(namespace = "main"): EventDispatcher {
     const result = EventDispatcher.instances[namespace];
     if (!result) {
       return new this(namespace);
@@ -29,10 +29,10 @@ export class EventDispatcher {
    */
   private events: Events = {};
 
-  private _namespace: string;
+  private _namespace = "anonymous";
 
   public get namespace(): string {
-    return this._namespace || "anonymous";
+    return this._namespace;
   }
 
   /**
@@ -46,7 +46,6 @@ export class EventDispatcher {
       this._namespace = namespace;
       EventDispatcher.instances[namespace] = this;
       return EventDispatcher.instances[namespace];
-      this._namespace = namespace;
     }
   }
 

--- a/packages/core/src/services/event-dispatcher.service.ts
+++ b/packages/core/src/services/event-dispatcher.service.ts
@@ -116,9 +116,9 @@ export class EventDispatcher {
 
     for (let i = 0; i < this.events[eventName].length; i++) {
       if ((this.events[eventName][i] as BoundEventCallback | undefined)?.cb) {
-        (this.events[eventName][i] as BoundEventCallback).cb.apply(this, args);
+        (this.events[eventName][i] as BoundEventCallback).cb(...args);
       } else {
-        (this.events[eventName][i] as EventCallback).apply(this, args);
+        (this.events[eventName][i] as EventCallback)(...args);
       }
     }
   }

--- a/packages/core/src/services/event-dispatcher.service.ts
+++ b/packages/core/src/services/event-dispatcher.service.ts
@@ -70,7 +70,6 @@ export class EventDispatcher {
       this.events[eventName].push(cb);
     }
   }
-
   /**
    * Unbind event
    *
@@ -83,18 +82,19 @@ export class EventDispatcher {
       return;
     }
     if (cb !== undefined) {
-      for (let i = this.events[eventName].length - 1; i >= 0; i--) {
-        const curEvent = this.events[eventName][i] as BoundEventCallback;
-        if (curEvent.orgCb && curEvent.thisContext) {
-          if (typeof thisContext !== "undefined") {
-            if (curEvent.thisContext !== thisContext) {
-              continue;
-            }
+      if (thisContext !== undefined) {
+        for (let i = this.events[eventName].length - 1; i >= 0; i--) {
+          const curEvent = this.events[eventName][i] as BoundEventCallback;
+          if (curEvent.orgCb === cb && curEvent.thisContext === thisContext) {
+            this.events[eventName].splice(i, 1);
           }
-          if (curEvent.orgCb !== cb) {
-            continue;
+        }
+      } else {
+        for (let i = this.events[eventName].length - 1; i >= 0; i--) {
+          const curEvent = this.events[eventName][i] as EventCallback;
+          if (curEvent === cb) {
+            this.events[eventName].splice(i, 1);
           }
-          this.events[eventName].splice(i, 1);
         }
       }
     } else {

--- a/packages/core/src/services/event-dispatcher.service.ts
+++ b/packages/core/src/services/event-dispatcher.service.ts
@@ -16,9 +16,7 @@ export class EventDispatcher {
   public static getInstance(namespace: string) {
     const result = EventDispatcher.instances[namespace];
     if (!result) {
-      throw new Error(
-        `No EventDispatcher instance with namespace ${namespace} found!`
-      );
+      return new this(namespace);
     }
     return result;
   }
@@ -31,20 +29,25 @@ export class EventDispatcher {
    */
   private events: Events = {};
 
-  private namespace: string;
+  private _namespace: string;
+
+  public get namespace(): string {
+    return this._namespace || "anonymous";
+  }
 
   /**
    * Creates an singleton instance of Dispatcher.
    */
-  constructor(namespace = "main") {
-    this.namespace = namespace;
-
-    if (EventDispatcher.instances[this.namespace]) {
-      return EventDispatcher.instances[this.namespace];
+  constructor(namespace?: string) {
+    if (namespace) {
+      if (EventDispatcher.instances[namespace]) {
+        return EventDispatcher.instances[namespace];
+      }
+      this._namespace = namespace;
+      EventDispatcher.instances[namespace] = this;
+      return EventDispatcher.instances[namespace];
+      this._namespace = namespace;
     }
-
-    EventDispatcher.instances[this.namespace] = this;
-    return EventDispatcher.instances[this.namespace];
   }
 
   /**

--- a/packages/core/src/services/event-dispatcher.service.ts
+++ b/packages/core/src/services/event-dispatcher.service.ts
@@ -73,11 +73,15 @@ export class EventDispatcher {
   /**
    * Unbind event
    *
-   * @param eventName Name of the event
+   * @param eventName optional, Name of the event; if name not supplied all event listeners for all events will be removed
    * @param cb optional, if a callback is supplied, only event listeners using the supplied callback function will be removed
    * @param thisContext optional, if a callback is supplied, only event listeners using the supplied thisContext will be removed
    */
-  public off(eventName: string, cb?: EventCallback, thisContext?: any) {
+  public off(eventName?: string, cb?: EventCallback, thisContext?: any) {
+    if (eventName === undefined) {
+      this.events = {};
+      return;
+    }
     if (eventName in this.events === false) {
       return;
     }


### PR DESCRIPTION
Allow anonymous EventDispatcher instances (without own namespace).

- `new EventDispatcher()` will create a new independent EventDispatcher instance without namespace.
- `new EventDispatcher(namespace)` will get the existing EventDispatcher with the given namespace or create it.
- `EventDispatcher.getInstance(namespace)` will do the same as `new EventDispatcher(namespace)`. (will not throw Error if EventDispatcher for given namespace does not exist).
- `EventDispatcher.getInstance()` (without argument) will return the existing EventDispatcher with namespace "main" as default, (or create it, if it does not yet exist).