### PR TITLE
fix(binders): valid html for show binder

### DIFF
--- a/packages/core/src/binders/hide.binder.ts
+++ b/packages/core/src/binders/hide.binder.ts
@@ -8,7 +8,7 @@ export class HideBinder extends Binder<boolean, HTMLElement> {
   routine(el: HTMLElement, value: boolean) {
     el.style.display = value ? "none" : "";
     if (value) {
-      el.setAttribute("hidden", "true");
+      el.setAttribute("hidden", "");
     } else {
       el.removeAttribute("hidden");
     }

--- a/packages/core/src/binders/show.binder.ts
+++ b/packages/core/src/binders/show.binder.ts
@@ -10,7 +10,7 @@ export class ShowBinder extends Binder<boolean, HTMLElement> {
     if (value) {
       el.removeAttribute("hidden");
     } else {
-      el.setAttribute("hidden");
+      el.setAttribute("hidden", "");
     }
   }
 }

--- a/packages/core/src/binders/show.binder.ts
+++ b/packages/core/src/binders/show.binder.ts
@@ -10,7 +10,7 @@ export class ShowBinder extends Binder<boolean, HTMLElement> {
     if (value) {
       el.removeAttribute("hidden");
     } else {
-      el.setAttribute("hidden", "true");
+      el.setAttribute("hidden");
     }
   }
 }


### PR DESCRIPTION
A value for the `hidden` attribute is not allowed, so we don’t need to set it.

**Current Behaviour:**
`rv-show="foobar` will render `style="display: none;" hidden="true"`

**Expected Behaviour for valid HTML:**
`rv-show="foobar` will render `style="display: none;" hidden`

**References:**
https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute
https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attribute

Consider also adding/using `aria-hidden` values, but this would be a feature.